### PR TITLE
2 - Deprecation warnings on Perl 5.24

### DIFF
--- a/lib/Image/Compare/Comparator.pm
+++ b/lib/Image/Compare/Comparator.pm
@@ -143,7 +143,8 @@ sub import {
 		# We are essentially "exporting" this for backwards compatibility.  We
 		# don't really want to use constants like this any more, but we have
 		# to.  Shucks.
-		*{"Image::Compare::$name"} = sub () { $name };
+		my $name_const = $name;
+		*{"Image::Compare::$name"} = sub () { $name_const };
 		$Image::Compare::class_map{$name} = $cmp_pkg;
 		$Image::Compare::reverse_class_map{$cmp_pkg} = $name;
 	}


### PR DESCRIPTION
Warning "Constants from lexical variables potentially modified elsewhere are deprecated" fixed